### PR TITLE
[fixed] sync boombox on client join

### DIFF
--- a/ArmoredWarfare/Entities/Items/Boombox/Boombox.as
+++ b/ArmoredWarfare/Entities/Items/Boombox/Boombox.as
@@ -25,6 +25,20 @@ void onInit(CBlob@ this)
 	this.Tag("trap");
 }
 
+bool onReceiveCreateData(CBlob@ this, CBitStream@ stream)
+{
+	if (this.hasTag("broken quiet"))
+	{
+		CSprite@ sprite = this.getSprite();
+		
+		if (sprite !is null)
+			sprite.SetEmitSoundPaused(true);
+		
+		StopAnimation(this);
+	}
+	return true;
+}
+
 void onDie(CBlob@ this)
 {
 	CSprite@ sprite = this.getSprite();


### PR DESCRIPTION
When boombox is broken (by touching water), and a client joins later, it would still produce music and have animation.

This PR applies a fix so boombox will be quiet and have no animation when it is broken and a client joins after the fact.

I used the hook `bool onReceiveCreateData(CBlob@ this, CBitStream@ stream)`, which is also used in `Saw.as` to sync Saw sprite to clients on join.

I tested it in online dedicated server.
When boombox is intact --> after rejoining, it will still be intact
When boombox is breaking down --> after rejoining, it will continue to break down
When boombox is broken quiet --> after rejoining, it will be broken quiet still.