### PR TITLE
[fixed] Prioritize picking up burning molotov before non-burning molotov

### DIFF
--- a/ArmoredWarfare/Entities/Characters/Scripts/Controls/StandardPickup.as
+++ b/ArmoredWarfare/Entities/Characters/Scripts/Controls/StandardPickup.as
@@ -406,7 +406,7 @@ f32 getPriorityPickupScale(CBlob@ this, CBlob@ b)
 		return factor_extremely_important;
 	}
 
-	if((name == "molotov" || name == "agrenade" || name == "sgrenade" || name == "grenade"
+	if((name == "molotov" || name == "molotov_us" || name == "molotov_nazi" || name == "agrenade" || name == "sgrenade" || name == "grenade"
 		|| name == "atgrenade" || name == "mat_atgrenade"
 		&& (b.hasTag("activated") || b.get_u8("exploding_2") > 0))){
 		return factor_super_important; //pick up activated stuff before deactivated stuff


### PR DESCRIPTION
When a molotov of the type "us" and "nazi" was lying on the ground burning and a 2nd unactivated molotov was closer, you would pick up the unactivated molotov.

This PR fixing that so you will prioritize picking up the burning molotov even when it is further away, replicating the same behavior as with the regular molotovs.

Fixes https://github.com/NoahTheLegend/kaww/issues/160