### PR TITLE
[changed] Player can move cam sooner after death

### DIFF
--- a/ArmoredWarfare/Entities/Characters/Scripts/Runner/PlayerCamera.as
+++ b/ArmoredWarfare/Entities/Characters/Scripts/Runner/PlayerCamera.as
@@ -101,8 +101,6 @@ void onPlayerDie(CRules@ this, CPlayer@ victim, CPlayer@ attacker, u8 customData
 				SetTargetPlayer(null);
 
 			}
-			deathTime = getGameTime() + 2 * getTicksASecond();
-
 		}
 		else
 		{
@@ -123,10 +121,9 @@ void onPlayerDie(CRules@ this, CPlayer@ victim, CPlayer@ attacker, u8 customData
 				camera.setTarget(null);
 
 			}
-			deathTime = getGameTime() + 2 * getTicksASecond();
-
 		}
 
+		deathTime = getGameTime() + 1 * getTicksASecond();
 	}
 
 }


### PR DESCRIPTION
This is the same change as in vanilla https://github.com/transhumandesign/kag-base/commit/3628ce4f784f9ff13e9b52c26590d015929e8c70

Allows the player to move their camera after 1 second after death, rather than 2 seconds.

Which is better than having to wait ages if you e.g. fall out of the plane in the plane map and want to scroll the camera up.