### PR TITLE
[changed/fixed] Mechanic won't receive new pack of ammo

### DIFF
--- a/ArmoredWarfare/Rules/Core/Gamemode/TDM.as
+++ b/ArmoredWarfare/Rules/Core/Gamemode/TDM.as
@@ -1011,7 +1011,7 @@ shared class TDMCore : RulesCore
 
 	void GiveSpawnResources(CBlob@ blob, CPlayer@ player)
 	{
-		if (!(blob.getName() == "rpg" || blob.getName() == "firebringer"))
+		if (blob.getName() != "rpg" && blob.getName() != "firebringer" && blob.getName() != "mechanic")
 		{
 			// first check if its in surroundings
 			CBlob@[] blobsInRadius;


### PR DESCRIPTION
Fixes https://github.com/NoahTheLegend/kaww/issues/195

Antitank and Firebringer classes didn't receive ammo, but mechanic did although he can't use it.
This changes that so that no ammo is given to mechanic either.

Tested briefly in a dedicated server.
